### PR TITLE
Add LDAP authentication support to Prosody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
       lua-dbi-mysql \
       lua-expat \
       lua-filesystem \
+      lua-ldap \
       lua-socket \
       lua-sec \
       lua-unbound \

--- a/prosody.cfg.lua
+++ b/prosody.cfg.lua
@@ -15,7 +15,17 @@ c2s_require_encryption = os.getenv("C2S_REQUIRE_ENCRYPTION");
 s2s_require_encryption = os.getenv("S2S_REQUIRE_ENCRYPTION");
 s2s_secure_auth = os.getenv("S2S_SECURE_AUTH");
 
-authentication = "internal_hashed";
+authentication = os.getenv("AUTHENTICATION") or "internal_hashed";
+
+ldap_base = os.getenv("LDAP_BASE");
+ldap_server = os.getenv("LDAP_SERVER") or "localhost";
+ldap_rootdn = os.getenv("LDAP_ROOTDN") or "";
+ldap_password = os.getenv("LDAP_PASSWORD") or "";
+ldap_filter = os.getenv("LDAP_FILTER") or "(uid=$user)";
+ldap_scope = os.getenv("LDAP_SCOPE") or "subtree";
+ldap_tls = os.getenv("LDAP_TLS") or "false";
+ldap_mode = os.getenv("LDAP_MODE") or "bind";
+ldap_admin_filter = os.getenv("LDAP_ADMIN_FILTER") or "";
 
 log = {
     {levels = {min = os.getenv("LOG_LEVEL")}, to = "console"};

--- a/readme.md
+++ b/readme.md
@@ -197,34 +197,44 @@ sudo chown 999:999 ./data
 
 #### Environment variables
 
-| Variable                         | Description                                                                                                          | Type         | Default value              |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------ | -------------------------- |
-| **ALLOW_REGISTRATION**           | Whether to allow registration of new accounts via Jabber clients                                                     | *optional*   | true                       |
-| **DOMAIN**                       | domain                                                                                                               | **required** | null                       |
-| **DOMAIN_HTTP_UPLOAD**           | Domain which lets clients upload files over HTTP                                                                     | *optional*   | upload.**DOMAIN**          |
-| **DOMAIN_MUC**                   | Domain for Multi-user chat (MUC) for allowing you to create hosted chatrooms/conferences for XMPP users              | *optional*   | conference.**DOMAIN**      |
-| **DOMAIN_PROXY**                 | Domain for SOCKS5 bytestream proxy for server-proxied file transfers                                                 | *optional*   | proxy.**DOMAIN**           |
-| **DOMAIN_PUBSUB**                | Domain for a XEP-0060 pubsub service                                                                                 | *optional*   | pubsub.**DOMAIN**          |
-| **DB_DRIVER**                    | May also be "PostgreSQL" or "MySQL" or "SQLite3" (case sensitive!)                                                   | *optional*   | SQLite3                    |
-| **DB_DATABASE**                  | The database name to use. For SQLite3 this the database filename (relative to the data storage directory).           | *optional*   | prosody.sqlite             |
-| **DB_HOST**                      | The address of the database server                                                                                   | *optional*   |                            |
-| **DB_PORT**                      | Port on which the database is listening                                                                              | *optional*   |                            |
-| **DB_USERNAME**                  | The username to authenticate to the database                                                                         | *optional*   |                            |
-| **DB_PASSWORD**                  | The password to authenticate to the database                                                                         | *optional*   |                            |
-| **E2E_POLICY_CHAT**              | Policy for chat messages. Possible values: "none", "optional" and "required".                                        | *optional*   | "required"                 |
-| **E2E_POLICY_MUC**               | Policy for MUC messages. Possible values: "none", "optional" and "required".                                         | *optional*   | "required"                 |
-| **E2E_POLICY_WHITELIST**         | Make this module ignore messages sent to and from this JIDs or MUCs.                                                 | *optional*   | ""                         |
-| **LOG_LEVEL**                    | Min log level. Change to debug for more information                                                                  | *optional*   | info                       |
-| **C2S_REQUIRE_ENCRYPTION**       | Whether to force all client-to-server connections to be encrypted or not                                             | *optional*   | true                       |
-| **S2S_REQUIRE_ENCRYPTION**       | Whether to force all server-to-server connections to be encrypted or not                                             | *optional*   | true                       |
-| **S2S_SECURE_AUTH**              | Require encryption and certificate authentication                                                                    | *optional*   | true                       |
-| **SERVER_CONTACT_INFO_ABUSE**    | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*   | "xmpp:abuse@**DOMAIN**"    |
-| **SERVER_CONTACT_INFO_ADMIN**    | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*   | "xmpp:admin@**DOMAIN**"    |
-| **SERVER_CONTACT_INFO_FEEDBACK** | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*   | "xmpp:feedback@**DOMAIN**" |
-| **SERVER_CONTACT_INFO_SALES**    | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*   | "xmpp:sales@**DOMAIN**"    |
-| **SERVER_CONTACT_INFO_SECURITY** | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*   | "xmpp:security@**DOMAIN**" |
-| **SERVER_CONTACT_INFO_SUPPORT**  | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*   | "xmpp:support@**DOMAIN**"  |
-| **PROSODY_ADMINS**               | Specify who is an administrator. List of adresses. Eg. "me@example.com", "admin@example.net"                         | *optional*   | ""                         |
+| Variable                         | Description                                                                                                          | Type                                         | Default value              |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | -------------------------- |
+| **ALLOW_REGISTRATION**           | Whether to allow registration of new accounts via Jabber clients                                                     | *optional*                                   | true                       |
+| **DOMAIN**                       | domain                                                                                                               | **required**                                 | null                       |
+| **DOMAIN_HTTP_UPLOAD**           | Domain which lets clients upload files over HTTP                                                                     | *optional*                                   | upload.**DOMAIN**          |
+| **DOMAIN_MUC**                   | Domain for Multi-user chat (MUC) for allowing you to create hosted chatrooms/conferences for XMPP users              | *optional*                                   | conference.**DOMAIN**      |
+| **DOMAIN_PROXY**                 | Domain for SOCKS5 bytestream proxy for server-proxied file transfers                                                 | *optional*                                   | proxy.**DOMAIN**           |
+| **DOMAIN_PUBSUB**                | Domain for a XEP-0060 pubsub service                                                                                 | *optional*                                   | pubsub.**DOMAIN**          |
+| **AUTHENTICATION**               | authentication                                                                                                       | *optional*                                   | "internal_hashed"          |
+| **LDAP_BASE**                    | LDAP base directory which stores user accounts                                                                       | **required** if **AUTHENTICATION** is "ldap" |                            |
+| **LDAP_SERVER**                  | Space-separated list of hostnames or IPs, optionally with port numbers (e.g. “localhost:8389”)                       | *optional*                                   | "localhost"                |
+| **LDAP_ROOTDN**                  | The distinguished name to auth against                                                                               | *optional*                                   | ""                         |
+| **LDAP_PASSWORD**                | Password for rootdn                                                                                                  | *optional*                                   | ""                         |
+| **LDAP_FILTER**                  | Search filter, with $user and $host substituted for user- and hostname                                               | *optional*                                   | "(uid=$user)"              |
+| **LDAP_SCOPE**                   | Search scope. other values: “base” and “onelevel”                                                                    | *optional*                                   | "subtree"                  |
+| **LDAP_TLS**                     | Enable TLS (StartTLS) to connect to LDAP (can be true or false). The non-standard ‘LDAPS’ protocol is not supported. | *optional*                                   | "false"                    |
+| **LDAP_MODE**                    | How passwords are validated.                                                                                         | *optional*                                   | "bind"                     |
+| **LDAP_ADMIN_FILTER**            | Search filter to match admins, works like ldap_filter                                                                | *optional*                                   | ""                         |
+| **DB_DRIVER**                    | May also be "PostgreSQL" or "MySQL" or "SQLite3" (case sensitive!)                                                   | *optional*                                   | SQLite3                    |
+| **DB_DATABASE**                  | The database name to use. For SQLite3 this the database filename (relative to the data storage directory).           | *optional*                                   | prosody.sqlite             |
+| **DB_HOST**                      | The address of the database server                                                                                   | *optional*                                   |                            |
+| **DB_PORT**                      | Port on which the database is listening                                                                              | *optional*                                   |                            |
+| **DB_USERNAME**                  | The username to authenticate to the database                                                                         | *optional*                                   |                            |
+| **DB_PASSWORD**                  | The password to authenticate to the database                                                                         | *optional*                                   |                            |
+| **E2E_POLICY_CHAT**              | Policy for chat messages. Possible values: "none", "optional" and "required".                                        | *optional*                                   | "required"                 |
+| **E2E_POLICY_MUC**               | Policy for MUC messages. Possible values: "none", "optional" and "required".                                         | *optional*                                   | "required"                 |
+| **E2E_POLICY_WHITELIST**         | Make this module ignore messages sent to and from this JIDs or MUCs.                                                 | *optional*                                   | ""                         |
+| **LOG_LEVEL**                    | Min log level. Change to debug for more information                                                                  | *optional*                                   | info                       |
+| **C2S_REQUIRE_ENCRYPTION**       | Whether to force all client-to-server connections to be encrypted or not                                             | *optional*                                   | true                       |
+| **S2S_REQUIRE_ENCRYPTION**       | Whether to force all server-to-server connections to be encrypted or not                                             | *optional*                                   | true                       |
+| **S2S_SECURE_AUTH**              | Require encryption and certificate authentication                                                                    | *optional*                                   | true                       |
+| **SERVER_CONTACT_INFO_ABUSE**    | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*                                   | "xmpp:abuse@**DOMAIN**"    |
+| **SERVER_CONTACT_INFO_ADMIN**    | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*                                   | "xmpp:admin@**DOMAIN**"    |
+| **SERVER_CONTACT_INFO_FEEDBACK** | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*                                   | "xmpp:feedback@**DOMAIN**" |
+| **SERVER_CONTACT_INFO_SALES**    | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*                                   | "xmpp:sales@**DOMAIN**"    |
+| **SERVER_CONTACT_INFO_SECURITY** | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*                                   | "xmpp:security@**DOMAIN**" |
+| **SERVER_CONTACT_INFO_SUPPORT**  | A list of strings. Each string should be an URI. See [here](https://prosody.im/doc/modules/mod_server_contact_info). | *optional*                                   | "xmpp:support@**DOMAIN**"  |
+| **PROSODY_ADMINS**               | Specify who is an administrator. List of adresses. Eg. "me@example.com", "admin@example.net"                         | *optional*                                   | ""                         |
 
 #### DNS
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
-aioxmpp==0.13.2
+aioxmpp==0.13.3
 pip-chill==1.0.1
-pytest-asyncio==0.18.3
+pytest-asyncio==0.21.0
+pytz==2022.7.1


### PR DESCRIPTION
This commit adds support for LDAP authentication.

The Dockerfile has been modified to install the required Lua modules (lua-ldap) and the prosody.cfg.lua file has been modified to add environment variables for configuring the LDAP connection. These environment variables include LDAP_BASE, LDAP_SERVER, LDAP_ROOTDN, LDAP_PASSWORD, LDAP_FILTER, LDAP_SCOPE, LDAP_TLS, LDAP_MODE, and LDAP_ADMIN_FILTER.

The authentication variable has also been updated to use the value of the AUTHENTICATION environment variable, which defaults to "internal_hashed" if not set. This allows users to configure Prosody to use LDAP for authentication instead of the default internal hashing method.