### PR TITLE
Fix deprecated config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Adjust config
+
+* Replace deprecated legacy_ssl with c2s_direct_tls.
+* Removed use_libevent = true. This means the default is now used which is epoll.
+
+### Test
+
+Added a test to check that no deprecated config settings are used.
+
 ## v1.3.0
 
 * Updated to Prosody version [0.12.4](https://blog.prosody.im/prosody-0.12.4-released/)

--- a/conf.d/05-vhost.cfg.lua
+++ b/conf.d/05-vhost.cfg.lua
@@ -6,11 +6,11 @@ local domain_pubsub = os.getenv("DOMAIN_PUBSUB")
 
 -- XEP-0368: SRV records for XMPP over TLS
 -- https://compliance.conversations.im/test/xep0368/
-legacy_ssl_ssl = {
+c2s_direct_tls_ssl = {
 	certificate = "certs/" .. domain .. "/fullchain.pem";
 	key = "certs/" .. domain .. "/privkey.pem";
 }
-legacy_ssl_ports = { 5223 }
+c2s_direct_tls_ports = { 5223 }
 
 -- https://prosody.im/doc/certificates#service_certificates
 -- https://prosody.im/doc/ports#ssl_configuration

--- a/prosody.cfg.lua
+++ b/prosody.cfg.lua
@@ -7,8 +7,6 @@ admins = stringy.split(os.getenv("PROSODY_ADMINS"), ", ");
 
 pidfile = "/var/run/prosody/prosody.pid"
 
-use_libevent = true; -- improves performance
-
 allow_registration = os.getenv("ALLOW_REGISTRATION");
 
 c2s_require_encryption = os.getenv("C2S_REQUIRE_ENCRYPTION");

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   prosody:
     image: prosody

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -57,8 +57,8 @@ load 'bats/bats-assert/load'
   assert_output
 }
 
-@test "Should activate legacy_ssl" {
-  run bash -c "sudo docker-compose logs $batsContainerName | grep -E \"Activated service 'legacy_ssl' on (\[::\]:5223|\[\*\]:5223), (\[::\]:5223|\[\*\]:5223)\""
+@test "Should activate c2s_direct_tls" {
+  run bash -c "sudo docker-compose logs $batsContainerName | grep -E \"Activated service 'c2s_direct_tls' on (\[::\]:5223|\[\*\]:5223), (\[::\]:5223|\[\*\]:5223)\""
   assert_success
   assert_output
 }
@@ -85,4 +85,9 @@ load 'bats/bats-assert/load'
   run bash -c "sudo docker-compose logs $batsContainerName | grep \"Serving 'file_share' at https:\/\/upload.example.com:5281\/file_share\""
   assert_success
   assert_output
+}
+
+@test "Should not use deprecated config" {
+  run bash -c "sudo docker-compose exec $batsContainerName /bin/bash -c \"/entrypoint.bash check\" | grep 'deprecated' -A 3"
+  assert_failure
 }


### PR DESCRIPTION
Adjust the config:
Replace deprecated legacy_ssl with c2s_direct_tls. Removed use_libevent = true. This means the default is now used which is epoll.

Added a test to check that no deprecated config settings are used.

This fixes https://github.com/SaraSmiseth/prosody/issues/62.